### PR TITLE
홈 태그별 페이지 조회 구현

### DIFF
--- a/src/config/res/response-status.ts
+++ b/src/config/res/response-status.ts
@@ -166,6 +166,10 @@ export class ResponseStatus extends EnumType<ResponseStatus>() {
     HttpStatus.OK,
     '사용자 태그 목록 조회 성공',
   );
+  static READ_ALL_PAGES_SUCCESS = new ResponseStatus(
+    HttpStatus.OK,
+    '페이지 목록 조회 성공',
+  );
 
   @Exclude() private readonly _httpStatus: HttpStatus;
   @Exclude() private readonly _message: string;

--- a/src/page/dto/page.response.dto.ts
+++ b/src/page/dto/page.response.dto.ts
@@ -66,16 +66,22 @@ export class PageResponseDto {
 
   @ApiProperty({
     example: ['imageUrl1', 'imageUrl2', 'imageUrl3'],
-    description: '사용자 ID',
+    description: '이미지 URL',
   })
-  images: string[];
+  images?: string[];
 
-  public static ofPage(page: Page, images: PageImage[], tags: any[]) {
+  @ApiProperty({
+    example: 1,
+    description: '이미지 개수',
+  })
+  imageCount?: number;
+
+  public static ofPage(page: Page, images: PageImage[], tags: any[]): PageResponseDto {
     return {
       userId: +page.userId,
       isPublic: page.isPublic,
-      projectId: +page.project.id,
-      projectTitle: page.project.title,
+      projectId: page.project == null ? null : +page.project.id,
+      projectTitle: page.project == null ? null : page.project.title,
       pageId: +page.id,
       title: page.title,
       content: page.content,
@@ -84,5 +90,21 @@ export class PageResponseDto {
       images: images.map((image) => image.imageUrl),
       tags: tags.map((tag) => TagResponseDto.ofPageTag(tag)),
     }
+  }
+
+  public static ofPageSimple(page: Page, imageCount: number, tags: any[]): PageResponseDto {
+    return {
+      userId: +page.userId,
+      isPublic: page.isPublic,
+      projectId: page.project == null ? null : +page.project.id,
+      projectTitle: page.project == null ? null : page.project.title,
+      pageId: +page.id,
+      title: page.title,
+      content: page.content,
+      startDate: page.startDate,
+      endDate: page.endDate,
+      imageCount: imageCount,
+      tags: tags.map((tag) => TagResponseDto.ofPageTag(tag)),
+    };
   }
 }

--- a/src/repositories/page-image.repository.ts
+++ b/src/repositories/page-image.repository.ts
@@ -9,6 +9,12 @@ export class PageImageRepository extends Repository<PageImage> {
     });
   }
 
+  public async getCountByPageId(pageId: number) {
+    return await this.count({
+      where: { pageId: pageId },
+    })
+  }
+
   public async deleteAllByPageId(pageId: number) {
     return this.createQueryBuilder('pageImage')
       .delete()

--- a/src/repositories/recommend-tag.repository.ts
+++ b/src/repositories/recommend-tag.repository.ts
@@ -5,7 +5,7 @@ import { EntityRepository, Repository } from 'typeorm';
 export class RecommendTagRepository extends Repository<RecommendTag> {
   public async findAll() {
     return await this.createQueryBuilder('recommendTag')
-      .innerJoinAndSelect('recommendTag.tag', 'tag')
+      .leftJoinAndSelect('recommendTag.tag', 'tag')
       .getMany();
   }
 }

--- a/src/repositories/user-tag.repository.ts
+++ b/src/repositories/user-tag.repository.ts
@@ -16,4 +16,12 @@ export class UserTagRepository extends Repository<UserTag> {
       .where('userTag.userId = :userId', { userId: userId })
       .getRawOne();
   }
+
+  public async findAllPagesByUserIdAndTagId(userId: number, tagId: number) {
+    return await this.createQueryBuilder('userTag')
+      .where('userTag.userId = :userId and userTag.tagId = :tagId', { userId: userId, tagId: tagId })
+      .leftJoinAndSelect('userTag.pageTags', 'pageTag')
+      .leftJoinAndSelect('pageTag.page', 'page')
+      .getOne();
+  }
 }

--- a/src/user/dto/story.response.dto.ts
+++ b/src/user/dto/story.response.dto.ts
@@ -72,12 +72,18 @@ export class StoryResponseDto {
   endDate: string;
 
   @ApiProperty({
+    example: 1,
+    description: "페이지 이미지 개수"
+  })
+  imageCount?: number;
+
+  @ApiProperty({
     example: [],
     description: "프로젝트/페이지 태그"
   })
   tags: TagResponseDto[];
 
-  public static ofProject(project: Project, tags: any[]) {
+  public static ofProject(project: Project, tags: any[]): StoryResponseDto {
     return {
       type: StoryType.PROJECT,
       userId: +project.userId,
@@ -92,7 +98,7 @@ export class StoryResponseDto {
     }
   }
 
-  public static ofPage(page: Page, tags: any[]) {
+  public static ofPage(page: Page, imageCount: number, tags: any[]): StoryResponseDto {
     return {
       type: StoryType.PAGE,
       userId: +page.userId,
@@ -102,6 +108,7 @@ export class StoryResponseDto {
       content: page.content,
       startDate: page.startDate,
       endDate: page.endDate,
+      imageCount: imageCount,
       tags: tags.map((tag) => TagResponseDto.ofPageTag(tag)),
     };
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Req } from '@nestjs/common';
+import { Controller, Get, Param, Query, Req } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ResponseEntity } from 'src/config/res/response-entity';
 import { ResponseStatus } from 'src/config/res/response-status';
@@ -48,5 +48,13 @@ export class UserController {
   async getStory(@Param('userId') userId: number) {
     const data = await this.userService.getStory(userId);
     return ResponseEntity.OK_WITH(ResponseStatus.READ_ALL_STORY_SUCCESS, data);
+  }
+
+  @ApiOperation({ summary: "본인 태그별 페이지 목록 조회" })
+  @ApiOkResponse()
+  @Get('/page')
+  async getPageByTag(@Req() req, @Query('tag') tag: number) {
+    const data = await this.userService.getPageByTag(req.user.userId, tag);
+    return ResponseEntity.OK_WITH(ResponseStatus.READ_ALL_PAGES_SUCCESS, data);
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -54,7 +54,7 @@ export class UserController {
   @ApiOkResponse()
   @Get('/page')
   async getPageByTag(@Req() req, @Query('tag') tag: number) {
-    const data = await this.userService.getPageByTag(req.user.userId, tag);
+    const data = await this.userService.getPagesByTag(req.user.userId, tag);
     return ResponseEntity.OK_WITH(ResponseStatus.READ_ALL_PAGES_SUCCESS, data);
   }
 }


### PR DESCRIPTION
## 개요
> 홈 태그별 페이지 조회 구현

## 작업내용
- 본인 홈 내에서 태그별로 페이지를 조회할 수 있도록 구현
- 스토리 조회, 페이지 조회 시에 이미지 개수를 응답하도록 추가

## 참고사항
- resolve: #28 
